### PR TITLE
--session-dir arg to configure where session files are stored

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import spotipy
 import tidalapi
 import webbrowser
 import yaml
 
-def open_spotify_session(config):
+def open_spotify_session(config, session_dir):
+    cache_path = os.path.join(session_dir, '.cache-' + config['username'])
     credentials_manager = spotipy.SpotifyOAuth(username=config['username'],
 				       scope='playlist-read-private',
 				       client_id=config['client_id'],
 				       client_secret=config['client_secret'],
-				       redirect_uri=config['redirect_uri'])
+				       redirect_uri=config['redirect_uri'],
+                       cache_path=cache_path)
     try:
         credentials_manager.get_access_token(as_dict=False)
     except spotipy.SpotifyOauthError:
@@ -19,9 +22,10 @@ def open_spotify_session(config):
 
     return spotipy.Spotify(oauth_manager=credentials_manager)
 
-def open_tidal_session():
+def open_tidal_session(session_dir):
+    session_filepath = os.path.join(session_dir, '.session.yml')
     try:
-        with open('.session.yml', 'r') as session_file:
+        with open(session_filepath, 'r') as session_file:
             previous_session = yaml.safe_load(session_file)
     except OSError:
         previous_session = None
@@ -44,7 +48,7 @@ def open_tidal_session():
         url = 'https://' + url
     webbrowser.open(url)
     future.result()
-    with open('.session.yml', 'w') as f:
+    with open(session_filepath, 'w') as f:
         yaml.dump( {'session_id': session.session_id,
                    'token_type': session.token_type,
                    'access_token': session.access_token,

--- a/sync.py
+++ b/sync.py
@@ -59,7 +59,7 @@ def artist_match(tidal_track, spotify_track):
         return set([simple(x.strip().lower()) for x in result])
     # There must be at least one overlapping artist between the Tidal and Spotify track
     return get_tidal_artists(tidal_track).intersection(get_spotify_artists(spotify_track)) != set()
-  
+
 def match(tidal_track, spotify_track):
     return duration_match(tidal_track, spotify_track) and name_match(tidal_track, spotify_track) and artist_match(tidal_track, spotify_track)
 
@@ -282,12 +282,13 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', default='config.yml', help='location of the config file')
     parser.add_argument('--uri', help='synchronize a specific URI instead of the one in the config')
+    parser.add_argument('--session-dir', default='./', help='location of where session files are stored')
     args = parser.parse_args()
 
     with open(args.config, 'r') as f:
         config = yaml.safe_load(f)
-    spotify_session = open_spotify_session(config['spotify'])
-    tidal_session = open_tidal_session()
+    spotify_session = open_spotify_session(config['spotify'], args.session_dir)
+    tidal_session = open_tidal_session(args.session_dir)
     if not tidal_session.check_login():
         sys.exit("Could not connect to Tidal")
     if args.uri:


### PR DESCRIPTION
Added a new `--session-dir` arg to configure where session data is stored. Default behaviour is not changed with the value defaulting to `./` if not provided.

Having it configurable makes it easier to isolate the session files which need to persist, when running the script in a docker container. 