### PR TITLE
Added a ISRC matcher

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -82,11 +82,10 @@ def artist_match(tidal_track, spotify_track):
     return get_tidal_artists(tidal_track, True).intersection(get_spotify_artists(spotify_track, True)) != set()
 
 def match(tidal_track, spotify_track):
-    return (
-            isrc_match(tidal_track, spotify_track)
-            or duration_match(tidal_track, spotify_track)
-            and name_match(tidal_track, spotify_track)
-            and artist_match(tidal_track, spotify_track)
+    return isrc_match(tidal_track, spotify_track) or (
+        duration_match(tidal_track, spotify_track)
+        and name_match(tidal_track, spotify_track)
+        and artist_match(tidal_track, spotify_track)
     )
 
 


### PR DESCRIPTION
Now with the upgrade to tidalapi 0.7.0 we have access from the Tidal side to each track [ISRC](https://en.wikipedia.org/wiki/International_Standard_Recording_Code), which allows us to cross that information with what was already available via the spotipy package. In due course, I added the function `isrc_match(tidal_track, spotify_track)`. This matcher is executed before the others as I gave it precedence, since we may call an ISRC match the ultimate match so to speak.

@timrae Thank you for your work and sharing it online!