### PR TITLE
Bump tidalapi to 0.7.1 and add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Config and cache files
+config.yml
+config.yaml
+.cache-*
+.session.yml
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+eggs/
+.eggs/
+sdist/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environments
+.env
+.venv
+env/
+venv/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spotipy==2.21.0
 requests>=2.28.1 # for tidalapi
-tidalapi==0.7.0
+tidalapi==0.7.1
 pyyaml==6.0
 tqdm==4.64.1


### PR DESCRIPTION
This fixes #19 and adds a gitignore file to filter out python stuff as well as all the config and session files that this script generates that should never be committed 