### PR TITLE
Added Tidal search exclusion rules config (and ConfigHolder class)

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -4,6 +4,13 @@ spotify:
   username: your_spotify_username
   redirect_uri: http://localhost:8888/callback
 
+# patterns to exclude tracks from Tidal search when name matching against Spotify track
+exclusion_rules:
+  - instrumental
+  - acapella
+  - remix
+  - karaoke
+
 
 # uncomment this block if you want to only sync specific playlist IDs
 #sync_playlists:


### PR DESCRIPTION
Hello again,

I had some problems with karaoke versions of tracks showing up in my playlists, so I thought of applying this small refactoring. Moved the exclusion rules to the yaml config file and introduced a ConfigHolder class for easier access of configs.

Like in my previous pull request, if you have any comment regarding improvements or whatnot please be free to reach back, I will try to comply promptly.