### PR TITLE
Various small improvements

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -13,3 +13,7 @@ spotify:
 # uncomment this block if you want to sync all playlists in the account with some exceptions
 #excluded_playlists:
 #  - spotify:playlist:1ABCDEqsABCD6EaABCDa0a
+
+# number of concurrent subprocesses when searching tracks in a playlist.
+# increasing this value can improve sync speed, but may increase 429 errors
+subprocesses: 25

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Installation
 Clone this git repository and then run:
 
 ```bash
-python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
 ```
 
 Setup
@@ -18,18 +18,16 @@ Setup
 
 Usage
 ----
-To synchronize all of your Spotify playlists with your Tidal account run the following
+To synchronize all of your Spotify playlists with your Tidal account run the following from the project root directory
 
 ```bash
-python3 sync.py
+spotify_to_tidal
 ```
-
-This will take a long time because the Tidal API is really slow.
 
 You can also just synchronize a specific playlist by doing the following:
 
 ```bash
-python3 sync.py --uri 1ABCDEqsABCD6EaABCDa0a
+spotify_to_tidal --uri 1ABCDEqsABCD6EaABCDa0a # accepts playlist id or full playlist uri
 ```
 
-See example_config.yml for more configuration options, and `sync.py --help` for more options.
+See example_config.yml for more configuration options, and `spotify_to_tidal --help` for more options.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-spotipy==2.21.0
-requests>=2.28.1 # for tidalapi
-tidalapi==0.7.2
-pyyaml==6.0
-tqdm==4.64.1

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -13,7 +13,9 @@ def main():
 
     with open(args.config, 'r') as f:
         config = yaml.safe_load(f)
+    print("Opening Spotify session")
     spotify_session = _auth.open_spotify_session(config['spotify'])
+    print("Opening Tidal session")
     tidal_session = _auth.open_tidal_session()
     if not tidal_session.check_login():
         sys.exit("Could not connect to Tidal")

--- a/src/spotify_to_tidal/auth.py
+++ b/src/spotify_to_tidal/auth.py
@@ -16,7 +16,8 @@ def open_spotify_session(config) -> spotipy.Spotify:
 				       scope='playlist-read-private',
 				       client_id=config['client_id'],
 				       client_secret=config['client_secret'],
-				       redirect_uri=config['redirect_uri'])
+				       redirect_uri=config['redirect_uri'],
+				       requests_timeout=2)
     try:
         credentials_manager.get_access_token(as_dict=False)
     except spotipy.SpotifyOauthError:

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -234,7 +234,7 @@ def sync_playlist(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Sess
         return
 
     task_description = "Searching Tidal for {}/{} tracks in Spotify playlist '{}'".format(len(spotify_tracks) - cache_hits, len(spotify_tracks), spotify_playlist['name'])
-    tidal_tracks = call_async_with_progress(tidal_search, spotify_tracks, task_description, config.get('subprocesses', 50), tidal_session=tidal_session)
+    tidal_tracks = call_async_with_progress(tidal_search, spotify_tracks, task_description, config.get('subprocesses', 25), tidal_session=tidal_session)
     for index, tidal_track in enumerate(tidal_tracks):
         spotify_track = spotify_tracks[index][0]
         if tidal_track:


### PR DESCRIPTION
* Set 2s timeout when connecting to Spotify
    * Prevents a very long hang when IPv6 is flakey, which seems to be quite often for me
    * On IPv6 failure the http library will try again with IPv4
* Show more progress updates when starting up the script to reduce the time duration where it seems to be frozen
* Reduce default num subprocesses
    * 50 was causing a lot of 429 errors for me with recent changes to caching
* Parallelize fetching of the Spotify playlist tracks
* Update readme and remove redundant `requirements.txt` file