### PR TITLE
Fix incorrect track inserted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spotify_to_tidal"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">= 3.10"
 
 dependencies = [

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -85,6 +85,7 @@ def artist_match(tidal_track: tidalapi.Track, spotify_track) -> bool:
     return get_tidal_artists(tidal_track, True).intersection(get_spotify_artists(spotify_track, True)) != set()
 
 def match(tidal_track, spotify_track) -> bool:
+    if not spotify_track['id']: return False
     return isrc_match(tidal_track, spotify_track) or (
         duration_match(tidal_track, spotify_track)
         and name_match(tidal_track, spotify_track)
@@ -214,6 +215,7 @@ def get_tracks_for_new_tidal_playlist(spotify_tracks: Sequence[t_spotify.Spotify
     output = []
     seen_tracks = set()
     for spotify_track in spotify_tracks:
+        if not spotify_track['id']: continue
         tidal_id = track_match_cache.get(spotify_track['id'])
         if tidal_id and not tidal_id in seen_tracks:
             output.append(tidal_id)


### PR DESCRIPTION
Some playlists have tracks without a valid spotify id, for example if they're no longer on Spotify... Some of the new code from #43 was causing incorrect behaviour when this was happening, so I've added a shortcut that ignores these tracks. We might want to revisit this strategy for cases where the track was previously available on Spotify but no longer is, however it might still be available on Tidal.