### PR TITLE
WIP sync favorites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ venv/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Visual Studio Code
+.vscode/

--- a/example_config.yml
+++ b/example_config.yml
@@ -9,9 +9,7 @@ spotify:
 #sync_playlists:
 #  - spotify_id: 1ABCDEqsABCD6EaABCDa0a
 #    tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
-# sync favorites playlist
-#  - spotify_id: favorites
-#    tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
+
 
 # uncomment this block if you want to sync all playlists in the account with some exceptions
 #excluded_playlists:

--- a/example_config.yml
+++ b/example_config.yml
@@ -9,6 +9,9 @@ spotify:
 #sync_playlists:
 #  - spotify_id: 1ABCDEqsABCD6EaABCDa0a
 #    tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
+# sync favorites playlist
+#  - spotify_id: favorites
+#    tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
 
 # uncomment this block if you want to sync all playlists in the account with some exceptions
 #excluded_playlists:

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -9,7 +9,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', default='config.yml', help='location of the config file')
     parser.add_argument('--uri', help='synchronize a specific URI instead of the one in the config')
-    parser.add_argument('--disable-favorites-sync', action='store_true', help='disable synchronization of favorites')
+    parser.add_argument('--sync-favorites', action='store_true', help='enable synchronization of favorites')
     args = parser.parse_args()
 
     with open(args.config, 'r') as f:
@@ -33,7 +33,7 @@ def main():
         # otherwise just use the user playlists in the Spotify account
         _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)
 
-    if not args.disable_favorites_sync:
+    if args.sync_favorites:
         _sync.sync_favorites_wrapper(spotify_session, tidal_session, config)
 
 if __name__ == '__main__':

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -9,6 +9,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', default='config.yml', help='location of the config file')
     parser.add_argument('--uri', help='synchronize a specific URI instead of the one in the config')
+    parser.add_argument('--mode', default='playlists', help='mode to run in, either playlists or favorites')
     args = parser.parse_args()
 
     with open(args.config, 'r') as f:
@@ -25,6 +26,16 @@ def main():
         tidal_playlists = _sync.get_tidal_playlists_dict(tidal_session)
         tidal_playlist = _sync.pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists)
         _sync.sync_list(spotify_session, tidal_session, [tidal_playlist], config)
+    elif args.mode == "favorites":
+        # sync the favorites list
+        favorites_mapping = next((item for item in config.get('sync_playlists', []) if item['spotify_id'] == 'favorites'), None)
+        if favorites_mapping:
+            tidal_playlist_id = favorites_mapping['tidal_id']
+        else:
+            tidal_playlist_id = input("Please enter the Tidal playlist ID for your Spotify favorites: ")
+
+        _sync.sync_favorites_wrapper(spotify_session, tidal_session, tidal_playlist_id, config)
+    
     elif config.get('sync_playlists', None):
         # if the config contains a sync_playlists list of mappings then use that
         _sync.sync_list(spotify_session, tidal_session, _sync.get_playlists_from_config(spotify_session, tidal_session, config), config)

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -9,7 +9,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', default='config.yml', help='location of the config file')
     parser.add_argument('--uri', help='synchronize a specific URI instead of the one in the config')
-    parser.add_argument('--mode', default='playlists', help='mode to run in, either playlists or favorites')
+    parser.add_argument('--disable-favorites-sync', action='store_true', help='disable synchronization of favorites')
     args = parser.parse_args()
 
     with open(args.config, 'r') as f:
@@ -25,23 +25,16 @@ def main():
         spotify_playlist = spotify_session.playlist(args.uri)
         tidal_playlists = _sync.get_tidal_playlists_dict(tidal_session)
         tidal_playlist = _sync.pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists)
-        _sync.sync_list(spotify_session, tidal_session, [tidal_playlist], config)
-    elif args.mode == "favorites":
-        # sync the favorites list
-        favorites_mapping = next((item for item in config.get('sync_playlists', []) if item['spotify_id'] == 'favorites'), None)
-        if favorites_mapping:
-            tidal_playlist_id = favorites_mapping['tidal_id']
-        else:
-            tidal_playlist_id = input("Please enter the Tidal playlist ID for your Spotify favorites: ")
-
-        _sync.sync_favorites_wrapper(spotify_session, tidal_session, tidal_playlist_id, config)
-    
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, [tidal_playlist], config)
     elif config.get('sync_playlists', None):
         # if the config contains a sync_playlists list of mappings then use that
-        _sync.sync_list(spotify_session, tidal_session, _sync.get_playlists_from_config(spotify_session, tidal_session, config), config)
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_playlists_from_config(spotify_session, tidal_session, config), config)
     else:
         # otherwise just use the user playlists in the Spotify account
-        _sync.sync_list(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)
+
+    if not args.disable_favorites_sync:
+        _sync.sync_favorites_wrapper(spotify_session, tidal_session, config)
 
 if __name__ == '__main__':
     main()

--- a/src/spotify_to_tidal/auth.py
+++ b/src/spotify_to_tidal/auth.py
@@ -13,7 +13,7 @@ __all__ = [
 
 def open_spotify_session(config) -> spotipy.Spotify:
     credentials_manager = spotipy.SpotifyOAuth(username=config['username'],
-				       scope='playlist-read-private',
+				       scope='playlist-read-private, user-library-read',
 				       client_id=config['client_id'],
 				       client_secret=config['client_secret'],
 				       redirect_uri=config['redirect_uri'],

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -243,71 +243,79 @@ def get_tracks_for_new_tidal_playlist(spotify_tracks: Sequence[t_spotify.Spotify
             seen_tracks.add(tidal_id)
     return output
 
-async def sync_playlist(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, spotify_playlist, tidal_playlist: tidalapi.Playlist | None, config, sync_favorites=False):
+async def sync_tracks(spotify_tracks: Sequence[t_spotify.SpotifyTrack], old_tidal_tracks: Sequence[tidalapi.Track], config, tidal_session: tidalapi.Session, tidal_playlist: tidalapi.UserPlaylist, sync_favorites: bool = False):
     async def _run_rate_limiter(semaphore):
         ''' Leaky bucket algorithm for rate limiting. Periodically releases an item from semaphore at rate_limit'''
         while True:
-            await asyncio.sleep(1/config.get('rate_limit', 12)) # sleep for min time between new function executions
+            await asyncio.sleep(delay=1/config.get('rate_limit', 12)) # sleep for min time between new function executions
             semaphore.release() # leak one item from the 'bucket'
 
-    # Create a new Tidal playlist if required
-    if not tidal_playlist:
-        print(f"No playlist found on Tidal corresponding to Spotify playlist: '{spotify_playlist['name']}', creating new playlist")
-        tidal_playlist =  tidal_session.user.create_playlist(spotify_playlist['name'], spotify_playlist['description'])
-
-    spotify_tracks = []
-    # Extract the new tracks from the playlist that we haven't already seen before
-    if sync_favorites:
-        spotify_tracks = spotify_playlist['tracks']
-    else:
-        print(spotify_playlist)
-        spotify_tracks = await get_tracks_from_spotify_playlist(spotify_session, spotify_playlist)
-    
-    old_tidal_tracks = tidal_playlist.tracks()
-    tracks_to_search = get_new_tracks_from_spotify_playlist(spotify_tracks, old_tidal_tracks)
+    tracks_to_search: List[t_spotify.SpotifyTrack] = get_new_tracks_from_spotify_playlist(spotify_tracks=spotify_tracks, old_tidal_tracks=old_tidal_tracks)
     if not tracks_to_search:
-        print("No new tracks to search in Spotify playlist '{}'".format(spotify_playlist['name']))
+        print("No new tracks to search in Spotify tracks")
         return
 
     # Search for each of the tracks on Tidal concurrently
-    task_description = "Searching Tidal for {}/{} tracks in Spotify playlist '{}'".format(len(tracks_to_search), len(spotify_tracks), spotify_playlist['name'])
-    semaphore = asyncio.Semaphore(config.get('max_concurrency', 10))
-    rate_limiter_task = asyncio.create_task(_run_rate_limiter(semaphore))
-    search_results = await atqdm.gather( *[ repeat_on_request_error(tidal_search, t, semaphore, tidal_session) for t in tracks_to_search ], desc=task_description )
+    task_description = "Searching Tidal for {}/{} Spotify tracks".format(len(tracks_to_search), len(spotify_tracks))
+    semaphore = asyncio.Semaphore(value=config.get('max_concurrency', 10))
+    rate_limiter_task = asyncio.create_task(coro=_run_rate_limiter(semaphore=semaphore))
+    search_results = await atqdm.gather(
+        *[repeat_on_request_error(tidal_search, t, semaphore, tidal_session) for t in tracks_to_search],
+        desc=task_description
+    )
     rate_limiter_task.cancel()
 
     # Add the search results to the cache
-    for idx, spotify_track in enumerate(tracks_to_search):
+    for idx, spotify_track in enumerate(iterable=tracks_to_search):
         if search_results[idx]:
-            track_match_cache.insert( (spotify_track['id'], search_results[idx].id) )
+            track_match_cache.insert(mapping=(spotify_track['id'], search_results[idx].id))
         else:
             color = ('\033[91m', '\033[0m')
             print(color[0] + "Could not find track {}: {} - {}".format(spotify_track['id'], ",".join([a['name'] for a in spotify_track['artists']]), spotify_track['name']) + color[1])
 
-    # Update the Tidal playlist if there are changes
+    # Update the Tidal playlist or favorites if there are changes
     old_tidal_track_ids = [t.id for t in old_tidal_tracks]
-    new_tidal_track_ids = get_tracks_for_new_tidal_playlist(spotify_tracks)
+    new_tidal_track_ids = get_tracks_for_new_tidal_playlist(spotify_tracks=spotify_tracks)
     if new_tidal_track_ids == old_tidal_track_ids:
-        print("No changes to write to Tidal playlist")
+        print("No changes to write to Tidal")
     elif new_tidal_track_ids[:len(old_tidal_track_ids)] == old_tidal_track_ids:
-        # Append new tracks to the existing playlist if possible
-        add_multiple_tracks_to_playlist(tidal_playlist, new_tidal_track_ids[len(old_tidal_track_ids):])
+        # Append new tracks to the existing playlist or favorites if possible
+        add_multiple_tracks_to_playlist(
+            playlist=tidal_playlist,
+            session=tidal_session,
+            track_ids=new_tidal_track_ids[len(old_tidal_track_ids):], 
+            sync_favorites=sync_favorites
+        )
     else:
-        # Erase old playlist and add new tracks from scratch if any reordering occured
-        set_tidal_playlist(tidal_playlist, new_tidal_track_ids)
+        # Erase old playlist or favorites and add new tracks from scratch if any reordering occured
+        set_tidal_playlist(
+            playlist=tidal_playlist,
+            session=tidal_session,
+            track_ids=new_tidal_track_ids, 
+            sync_favorites=sync_favorites
+        )
 
-def sync_list(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, playlists, config):
-  for spotify_playlist, tidal_playlist in playlists:
-    # sync the spotify playlist to tidal
-    asyncio.run(sync_playlist(spotify_session, tidal_session, spotify_playlist, tidal_playlist, config) )
+def sync_playlists_wrapper(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, playlists, config):
+    for spotify_playlist, tidal_playlist in playlists:
+        asyncio.run(main=sync_playlist(spotify_session=spotify_session, tidal_session=tidal_session, spotify_playlist=spotify_playlist, tidal_playlist=tidal_playlist, config=config) )
 
-async def sync_favorites(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, tidal_playlist_id: str, config):
-    tidal_playlist = tidal_session.playlist(tidal_playlist_id)
-    spotify_tracks = await get_tracks_from_spotify_favorites(spotify_session)
-    await sync_playlist(spotify_session, tidal_session, {'name': 'Favorites', 'tracks': spotify_tracks}, tidal_playlist, config, sync_favorites=True)
+async def sync_playlist(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, spotify_playlist, tidal_playlist: tidalapi.Playlist | None, config):
+    # Create a new Tidal playlist if required
+    if not tidal_playlist:
+        print(f"No playlist found on Tidal corresponding to Spotify playlist: '{spotify_playlist['name']}', creating new playlist")
+        tidal_playlist = tidal_session.user.create_playlist(spotify_playlist['name'], spotify_playlist['description'])
 
-def sync_favorites_wrapper(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, tidal_playlist_id: str, config):
-    asyncio.run(sync_favorites(spotify_session, tidal_session, tidal_playlist_id, config))
+    spotify_tracks = await get_tracks_from_spotify_playlist(spotify_session=spotify_session, spotify_playlist=spotify_playlist)
+    old_tidal_tracks = tidal_playlist.tracks()
+    await sync_tracks(spotify_tracks=spotify_tracks, old_tidal_tracks=old_tidal_tracks, config=config, tidal_session=tidal_session, tidal_playlist=tidal_playlist)
+
+def sync_favorites_wrapper(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, config):
+    asyncio.run(main=sync_favorites(spotify_session=spotify_session, tidal_session=tidal_session, config=config))
+
+async def sync_favorites(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, config):
+    spotify_tracks = await get_tracks_from_spotify_favorites(spotify_session=spotify_session)
+    old_tidal_tracks = tidal_session.user.favorites.tracks()
+    await sync_tracks(spotify_tracks=spotify_tracks, old_tidal_tracks=old_tidal_tracks, config=config, tidal_session=tidal_session, tidal_playlist=tidal_session.user.favorites, sync_favorites=True)
 
 def pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists: Mapping[str, tidalapi.Playlist]):
     if spotify_playlist['name'] in tidal_playlists:

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -180,7 +180,6 @@ async def get_tracks_from_spotify_favorites(spotify_session: spotipy.Spotify) ->
     output = []
     print("Loading favorite tracks from Spotify")
     results = _get_favorite_tracks(0, spotify_session)
-    print(f"Found {results['total']} favorite tracks")
     output.extend([item['track'] for item in results['items'] if item['track'] is not None])
 
     # get all the remaining tracks in parallel
@@ -258,9 +257,9 @@ async def sync_playlist(spotify_session: spotipy.Spotify, tidal_session: tidalap
     spotify_tracks = []
     # Extract the new tracks from the playlist that we haven't already seen before
     if sync_favorites:
-        print(spotify_playlist)
         spotify_tracks = spotify_playlist['tracks']
     else:
+        print(spotify_playlist)
         spotify_tracks = await get_tracks_from_spotify_playlist(spotify_session, spotify_playlist)
     
     old_tidal_tracks = tidal_playlist.tracks()
@@ -331,7 +330,7 @@ async def get_playlists_from_spotify(spotify_session: spotipy.Spotify, config):
     print("Loading Spotify playlists")
     results = spotify_session.user_playlists(config['spotify']['username'])
     exclude_list = set([x.split(':')[-1] for x in config.get('excluded_playlists', [])])
-      
+
     # get all the remaining playlists in parallel
     if results['next']:
         offsets = [ results['limit'] * n for n in range(1, math.ceil(results['total']/results['limit'])) ]
@@ -346,6 +345,8 @@ def get_playlists_from_config(spotify_session: spotipy.Spotify, tidal_session: t
         return [(item['spotify_id'], item['tidal_id']) for item in config['sync_playlists']]
     output = []
     for spotify_id, tidal_id in get_playlist_ids(config):
+        if spotify_id == 'favorites':
+            continue
         try:
             spotify_playlist = spotify_session.playlist(spotify_id)
         except spotipy.SpotifyException as e:

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -158,7 +158,6 @@ async def repeat_on_request_error(function, *args, remaining=5, **kwargs):
 
 async def _fetch_all_from_spotify_in_chunks(spotify_session: spotipy.Spotify, fetch_function: Callable, reverse: bool = False) -> List[dict]:
     output = []
-    print("Loading data from Spotify")
     results = fetch_function(0, spotify_session)
     output.extend([item['track'] for item in results['items'] if item['track'] is not None])
 

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -156,7 +156,7 @@ async def repeat_on_request_error(function, *args, remaining=5, **kwargs):
         return await repeat_on_request_error(function, *args, remaining=remaining-1, **kwargs)
 
 
-async def _fetch_all_from_spotify_in_chunks(spotify_session: spotipy.Spotify, fetch_function: Callable, reverse: bool = False) -> List[dict]:
+async def _fetch_all_from_spotify_in_chunks(spotify_session: spotipy.Spotify, fetch_function: Callable) -> List[dict]:
     output = []
     results = fetch_function(0, spotify_session)
     output.extend([item['track'] for item in results['items'] if item['track'] is not None])
@@ -169,9 +169,6 @@ async def _fetch_all_from_spotify_in_chunks(spotify_session: spotipy.Spotify, fe
         )
         for extra_result in extra_results:
             output.extend([item['track'] for item in extra_result['items'] if item['track'] is not None])
-    
-    if reverse:
-        output.reverse()
 
     return output
 
@@ -190,8 +187,9 @@ async def get_tracks_from_spotify_favorites(spotify_session: spotipy.Spotify) ->
         return spotify_session.current_user_saved_tracks(offset=offset)
 
     print("Loading favorite tracks from Spotify")
-    return await _fetch_all_from_spotify_in_chunks(spotify_session=spotify_session, fetch_function=_get_favorite_tracks, reverse=True)
-
+    tracks = await _fetch_all_from_spotify_in_chunks(spotify_session=spotify_session, fetch_function=_get_favorite_tracks)
+    tracks.reverse()
+    return tracks
 
 def populate_track_match_cache(spotify_tracks_: Sequence[t_spotify.SpotifyTrack], tidal_tracks_: Sequence[tidalapi.Track]):
     """ Populate the track match cache with all the existing tracks in Tidal playlist corresponding to Spotify playlist """

--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -314,7 +314,7 @@ def sync_favorites_wrapper(spotify_session: spotipy.Spotify, tidal_session: tida
 
 async def sync_favorites(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, config):
     spotify_tracks = await get_tracks_from_spotify_favorites(spotify_session=spotify_session)
-    old_tidal_tracks = tidal_session.user.favorites.tracks()
+    old_tidal_tracks = tidal_session.user.favorites.tracks(order='DATE')
     await sync_tracks(spotify_tracks=spotify_tracks, old_tidal_tracks=old_tidal_tracks, config=config, tidal_session=tidal_session, tidal_playlist=tidal_session.user.favorites, sync_favorites=True)
 
 def pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists: Mapping[str, tidalapi.Playlist]):

--- a/src/spotify_to_tidal/tidalapi_patch.py
+++ b/src/spotify_to_tidal/tidalapi_patch.py
@@ -14,16 +14,30 @@ def clear_tidal_playlist(playlist: tidalapi.UserPlaylist, chunk_size: int=20):
             indices = range(min(playlist.num_tracks, chunk_size))
             _remove_indices_from_playlist(playlist, indices)
             progress.update(len(indices))
-    
-def add_multiple_tracks_to_playlist(playlist: tidalapi.UserPlaylist, track_ids: List[int], chunk_size: int=20):
+
+def clear_favorites(session: tidalapi.Session):
+    favorite_tracks = session.user.favorites.tracks()
+    track_ids = [track.id for track in favorite_tracks]
+    for track_id in track_ids:
+        session.user.favorites.remove_track(track_id)
+
+def add_multiple_tracks_to_playlist(playlist: tidalapi.UserPlaylist, session: tidalapi.Session, track_ids: List[int], chunk_size: int = 20, sync_favorites: bool = False):
     offset = 0
-    with tqdm(desc="Adding new tracks to Tidal playlist", total=len(track_ids)) as progress:
+    with tqdm(desc="Adding new tracks to Tidal", total=len(track_ids)) as progress:
         while offset < len(track_ids):
             count = min(chunk_size, len(track_ids) - offset)
-            playlist.add(track_ids[offset:offset+chunk_size])
+            if sync_favorites:
+                for track_id in track_ids[offset:offset + chunk_size]:
+                    session.user.favorites.add_track(track_id)
+            else:
+                playlist.add(track_ids[offset:offset + chunk_size])
             offset += count
             progress.update(count)
 
-def set_tidal_playlist(playlist: tidalapi.Playlist, track_ids: List[int]):
-    clear_tidal_playlist(playlist)
-    add_multiple_tracks_to_playlist(playlist, track_ids)
+def set_tidal_playlist(playlist: tidalapi.Playlist, session: tidalapi.Session, track_ids: List[int], sync_favorites: bool=False):
+    if sync_favorites:
+        clear_favorites(session)
+    else:
+        clear_tidal_playlist(playlist=playlist)
+    add_multiple_tracks_to_playlist(playlist=playlist, session=session, track_ids=track_ids, sync_favorites=sync_favorites)
+


### PR DESCRIPTION
Allow users to sync their Spotify favorites with a tidal playlist.
In this implementation, there are two ways to configure the playlist:

Variant 1: Add this entry to the configuration file
``` 
- spotify_id: favorites
  tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
```

Then run the application in the favorites' mode:
`spotify_to_tidal --mode=favorites`

or alternately skip the configuration file and provide the playlist ID via the console.

I am looking forward to your feedback!