### PR TITLE
fix: sync first playlists page

### DIFF
--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -296,6 +296,7 @@ async def get_playlists_from_spotify(spotify_session: spotipy.Spotify, config):
     print("Loading Spotify playlists")
     results = spotify_session.user_playlists(config['spotify']['username'])
     exclude_list = set([x.split(':')[-1] for x in config.get('excluded_playlists', [])])
+    playlists.extend([p for p in results['items'] if p['owner']['id'] == config['spotify']['username'] and not p['id'] in exclude_list])
       
     # get all the remaining playlists in parallel
     if results['next']:


### PR DESCRIPTION
This commit: https://github.com/spotify2tidal/spotify_to_tidal/commit/1e8366a0e8e751186dc9d630ddce29e5fb7fa95f broke playlist loading. The first results coming back from the Spotify API were not added to the playlists array.