### PR TITLE
Fix rate limit accuracy

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -16,4 +16,4 @@ spotify:
 
 # increasing these parameters should increase the search speed, while decreasing reduces likelihood of 429 errors
 max_concurrency: 10 # max concurrent connections at any given time
-rate_limit:      12 # max sustained connections per second
+rate_limit:      10 # max sustained connections per second


### PR DESCRIPTION
Batching multiple updates to the leaky bucket at a fixed interval improves the accuracy of the rate limiter. Previously the rate would drop substantially over the course of the sync operation.