### PR TITLE
Performance optimization: Fetch Tidal data in chunks

### DIFF
--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -23,7 +23,7 @@ def main():
     if args.uri:
         # if a playlist ID is explicitly provided as a command line argument then use that
         spotify_playlist = spotify_session.playlist(args.uri)
-        tidal_playlists = _sync.get_tidal_playlists_dict(tidal_session)
+        tidal_playlists = _sync.get_tidal_playlists_wrapper(tidal_session)
         tidal_playlist = _sync.pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists)
         _sync.sync_playlists_wrapper(spotify_session, tidal_session, [tidal_playlist], config)
         sync_favorites = args.sync_favorites # only sync favorites if command line argument explicitly passed

--- a/src/spotify_to_tidal/tidalapi_patch.py
+++ b/src/spotify_to_tidal/tidalapi_patch.py
@@ -27,25 +27,53 @@ def add_multiple_tracks_to_playlist(playlist: tidalapi.UserPlaylist, track_ids: 
             offset += count
             progress.update(count)
 
-async def get_all_favorites(favorites: tidalapi.Favorites, order: str = "NAME", order_direction: str = "ASC",) -> List[tidalapi.Track]:
-    """ Get all favorites from Tidal playlist in chunks. The main library doesn't provide the total number of items or expose the raw json, so need this wrapper """
-    params = {
-        "limit": None,
-        "offset": 0,
-        "order": order,
-        "orderDirection": order_direction,
-    }
-    first_chunk_raw = favorites.requests.map_request(f"{favorites.base_url}/tracks", params)
+async def _get_all_chunks(url, session, parser, params={}) -> List[tidalapi.Track]:
+    """ 
+        Helper function to get all items from a Tidal endpoint in parallel
+        The main library doesn't provide the total number of items or expose the raw json, so use this wrapper instead
+    """
+    def _make_request(offset: int=0):
+        new_params = params
+        new_params['offset'] = offset
+        return session.request.map_request(url, params=new_params)
+
+    first_chunk_raw = _make_request()
     limit = first_chunk_raw['limit']
     total = first_chunk_raw['totalNumberOfItems']
-    tracks = favorites.session.request.map_json(first_chunk_raw, parse=favorites.session.parse_track)
+    items = session.request.map_json(first_chunk_raw, parse=parser)
 
-    if len(tracks) < total:
+    if len(items) < total:
         offsets = [limit * n for n in range(1, math.ceil(total/limit))]
         extra_results = await atqdm.gather(
-                *[asyncio.to_thread(lambda offset: favorites.tracks(offset=offset, order=order, order_direction=order_direction), offset) for offset in offsets],
+                *[asyncio.to_thread(lambda offset: session.request.map_json(_make_request(offset), parse=parser), offset) for offset in offsets],
             desc="Fetching additional data chunks"
         )
         for extra_result in extra_results:
-            tracks.extend(extra_result)
-    return tracks
+            items.extend(extra_result)
+    return items
+
+async def get_all_favorites(favorites: tidalapi.Favorites, order: str = "NAME", order_direction: str = "ASC", chunk_size: int=100) -> List[tidalapi.Track]:
+    """ Get all favorites from Tidal playlist in chunks """
+    params = {
+        "limit": chunk_size,
+        "order": order,
+        "orderDirection": order_direction,
+    }
+    return await _get_all_chunks(f"{favorites.base_url}/tracks", session=favorites.session, parser=favorites.session.parse_track, params=params)
+
+async def get_all_playlists(user: tidalapi.User, chunk_size: int=10) -> List[tidalapi.Playlist]:
+    """ Get all user playlists from Tidal in chunks """
+    print(f"Loading playlists from Tidal user")
+    params = {
+        "limit": chunk_size,
+    }
+    return await _get_all_chunks(f"users/{user.id}/playlists", session=user.session, parser=user.playlist.parse_factory, params=params)
+
+async def get_all_playlist_tracks(playlist: tidalapi.Playlist, chunk_size: int=20) -> List[tidalapi.Track]:
+    """ Get all tracks from Tidal playlist in chunks """
+    params = {
+        "limit": chunk_size,
+    }
+    print(f"Loading tracks from Tidal playlist '{playlist.name}'")
+    return await _get_all_chunks(f"{playlist._base_url%playlist.id}/tracks", session=playlist.session, parser=playlist.session.parse_track, params=params)
+


### PR DESCRIPTION
At the expense of relying on more internal implementation details of the Tidal api, this PR can significantly reduce the execution time of the script, especially when there are not many changes in the Spotify collection relative to last sync