### PR TITLE
Bump spotipy and pytest to more recent versions to allow building on nix unstable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ version = "1.0.0"
 requires-python = ">= 3.10"
 
 dependencies = [
-  "spotipy~=2.23.0",
+  "spotipy~=2.24.0",
   "tidalapi==0.7.6",
   "pyyaml~=6.0",
   "tqdm~=4.64",
   "sqlalchemy~=2.0",
-  "pytest~=7.0",
+  "pytest~=8.0",
   "pytest-mock~=3.8"
 ]
 


### PR DESCRIPTION
Build appears to work fine on my install with the updates.