### PR TITLE
Bidirectional sync between spotify and tidal

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -11,6 +11,18 @@ spotify:
 #  - spotify_id: 1ABCDEqsABCD6EaABCDa0a
 #    tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
 
+# uncomment this block if you want to sync spotify to tidal
+#sync_playlists:
+#  tidal:
+#    - spotify_id: 1ABCDEqsABCD6EaABCDa0a
+#      tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
+# uncomment this block if you want to sync tidal to spotify
+#  spotify:
+#    - spotify_id: 1ABCDEqsABCD6EaABCDa0a
+#      tidal_id: a0b1234-0a1b-012a-abcd-a1b234c5d6d7
+#  
+
+
 # uncomment this block if you want to sync all playlists in the account with some exceptions
 #excluded_playlists:
 #  - spotify:playlist:1ABCDEqsABCD6EaABCDa0a

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -20,27 +20,39 @@ def main():
     tidal_session = _auth.open_tidal_session()
     if not tidal_session.check_login():
         sys.exit("Could not connect to Tidal")
+    sync_favorites = args.sync_favorites or config.get('sync_favorites_default', False)
     if args.uri:
         # if a playlist ID is explicitly provided as a command line argument then use that
         spotify_playlist = spotify_session.playlist(args.uri)
         tidal_playlists = _sync.get_tidal_playlists_wrapper(tidal_session)
         tidal_playlist = _sync.pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists)
-        _sync.sync_playlists_wrapper(spotify_session, tidal_session, [tidal_playlist], config)
-        sync_favorites = args.sync_favorites # only sync favorites if command line argument explicitly passed
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, [tidal_playlist], config, to='spotify')
     elif args.sync_favorites:
         sync_favorites = True # sync only the favorites
     elif entries:=config.get('sync_playlists', None):
         if isinstance(entries, list):
             # if the config contains a sync_playlists list of mappings then use that
             playlist_map =  _sync.get_playlists_from_config(spotify_session, tidal_session, entries)
-            _sync.sync_playlists_wrapper(spotify_session, tidal_session, playlist_map, config)
-            sync_favorites = args.sync_favorites is None and config.get('sync_favorites_default', True)
+            _sync.sync_playlists_wrapper(spotify_session, tidal_session, playlist_map, config, to='tidal')
+        # should be a list
+        elif isinstance(entries, dict):
+            if x:= entries.get('tidal'):
+                playlist_map_tidal = _sync.get_playlists_from_config(spotify_session, tidal_session, x)
+                print("Syncing playlists from spotify to tidal.")
+            _sync.sync_playlists_wrapper(spotify_session, tidal_session, playlist_map_tidal, config, to='tidal')
+            if y:= entries.get('spotify'):
+                playlist_map_spotify = _sync.get_playlists_from_config(spotify_session, tidal_session, y)
+                print("Syncing playlists from tidal to spotify.")
+                _sync.sync_playlists_wrapper(spotify_session, tidal_session, playlist_map_spotify, config, to='spotify')
+                
+
     else:
         # otherwise sync all the user playlists in the Spotify account and favorites unless explicitly disabled
-        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)
-        sync_favorites = args.sync_favorites is None and config.get('sync_favorites_default', True)
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config, to='tidal')
 
     if sync_favorites:
+        print("Should not sync")
+        exit(1)
         _sync.sync_favorites_wrapper(spotify_session, tidal_session, config)
 
 if __name__ == '__main__':

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -29,10 +29,12 @@ def main():
         sync_favorites = args.sync_favorites # only sync favorites if command line argument explicitly passed
     elif args.sync_favorites:
         sync_favorites = True # sync only the favorites
-    elif config.get('sync_playlists', None):
-        # if the config contains a sync_playlists list of mappings then use that
-        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_playlists_from_config(spotify_session, tidal_session, config), config)
-        sync_favorites = args.sync_favorites is None and config.get('sync_favorites_default', True)
+    elif entries:=config.get('sync_playlists', None):
+        if isinstance(entries, list):
+            # if the config contains a sync_playlists list of mappings then use that
+            playlist_map =  _sync.get_playlists_from_config(spotify_session, tidal_session, entries)
+            _sync.sync_playlists_wrapper(spotify_session, tidal_session, playlist_map, config)
+            sync_favorites = args.sync_favorites is None and config.get('sync_favorites_default', True)
     else:
         # otherwise sync all the user playlists in the Spotify account and favorites unless explicitly disabled
         _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)

--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -51,8 +51,6 @@ def main():
         _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config, to='tidal')
 
     if sync_favorites:
-        print("Should not sync")
-        exit(1)
         _sync.sync_favorites_wrapper(spotify_session, tidal_session, config)
 
 if __name__ == '__main__':

--- a/src/spotify_to_tidal/auth.py
+++ b/src/spotify_to_tidal/auth.py
@@ -24,7 +24,7 @@ def open_spotify_session(config) -> spotipy.Spotify:
     try:
         credentials_manager.get_access_token(as_dict=False)
     except spotipy.SpotifyOauthError:
-        sys.exit("Error opening Spotify sesion; could not get token for username: ".format(config['username']))
+        sys.exit("Error opening Spotify session; could not get token for username: ".format(config['username']))
 
     return spotipy.Spotify(oauth_manager=credentials_manager)
 

--- a/src/spotify_to_tidal/auth.py
+++ b/src/spotify_to_tidal/auth.py
@@ -11,7 +11,7 @@ __all__ = [
     'open_tidal_session'
 ]
 
-SPOTIFY_SCOPES = 'playlist-read-private, user-library-read'
+SPOTIFY_SCOPES = 'playlist-read-private, user-library-read, playlist-modify-private, playlist-modify-public'
 
 def open_spotify_session(config) -> spotipy.Spotify:
     credentials_manager = spotipy.SpotifyOAuth(username=config['username'],
@@ -24,7 +24,7 @@ def open_spotify_session(config) -> spotipy.Spotify:
     try:
         credentials_manager.get_access_token(as_dict=False)
     except spotipy.SpotifyOauthError:
-        sys.exit("Error opening Spotify session; could not get token for username: ".format(config['username']))
+        sys.exit(f"Error opening Spotify session; could not get token for username: {config['username']}")
 
     return spotipy.Spotify(oauth_manager=credentials_manager)
 

--- a/src/spotify_to_tidal/tidalapi_patch.py
+++ b/src/spotify_to_tidal/tidalapi_patch.py
@@ -63,7 +63,7 @@ async def get_all_favorites(favorites: tidalapi.Favorites, order: str = "NAME", 
 
 async def get_all_playlists(user: tidalapi.User, chunk_size: int=10) -> List[tidalapi.Playlist]:
     """ Get all user playlists from Tidal in chunks """
-    print(f"Loading playlists from Tidal user")
+    print("Loading playlists from Tidal user")
     params = {
         "limit": chunk_size,
     }

--- a/src/spotify_to_tidal/type/__init__.py
+++ b/src/spotify_to_tidal/type/__init__.py
@@ -1,14 +1,14 @@
 from .config import SpotifyConfig, TidalConfig, PlaylistConfig, SyncConfig
 from .spotify import SpotifyTrack
-
+from typing import TypeAlias
 from spotipy import Spotify
 from tidalapi import Session, Track
 
-TidalID = str
-SpotifyID = str
-TidalSession = Session
-TidalTrack = Track
-SpotifySession = Spotify
+TidalID: TypeAlias = str
+SpotifyID: TypeAlias = str
+TidalSession: TypeAlias = Session
+TidalTrack: TypeAlias = Track
+SpotifySession: TypeAlias = Spotify
 
 __all__ = [
     "SpotifyConfig",

--- a/src/spotify_to_tidal/type/__init__.py
+++ b/src/spotify_to_tidal/type/__init__.py
@@ -1,4 +1,4 @@
-from .config import SpotifyConfig, TidalConfig, PlaylistConfig, SyncConfig
+from .config import SpotifyConfig, TidalConfig, PlaylistConfig, SyncConfig, PlaylistIDTuple, PlaylistConfigTuple
 from .spotify import SpotifyTrack
 from typing import TypeAlias
 from spotipy import Spotify
@@ -11,15 +11,16 @@ TidalTrack: TypeAlias = Track
 SpotifySession: TypeAlias = Spotify
 
 __all__ = [
-    "SpotifyConfig",
-    "TidalConfig",
     "PlaylistConfig",
-    "SyncConfig",
-    "TidalPlaylist",
-    "TidalID",
+    "PlaylistConfigTuple",
+    "PlaylistIDTuple",
+    "SpotifyConfig",
     "SpotifyID",
     "SpotifySession",
+    "SpotifyTrack",
+    "SyncConfig",
+    "TidalID",
+    "TidalConfig",
     "TidalSession",
     "TidalTrack",
-    "SpotifyTrack",
 ]

--- a/src/spotify_to_tidal/type/config.py
+++ b/src/spotify_to_tidal/type/config.py
@@ -1,6 +1,9 @@
-from typing import TypedDict, Literal, List, Optional
+from collections import namedtuple
+from typing import TypedDict, Literal
 
 
+PlaylistIDTuple = namedtuple('PlaylistIDTuple', ['spotify_id', 'tidal_id'])
+PlaylistConfigTuple = namedtuple("PlaylistConfig", ["spotify", "tidal"])
 class SpotifyConfig(TypedDict):
     client_id: str
     client_secret: str
@@ -20,7 +23,13 @@ class PlaylistConfig(TypedDict):
     tidal_id: str
 
 
+class SyncSourceConfig(TypedDict):
+    tidal: list[PlaylistConfig]
+    SpotifyConfig: list[PlaylistConfig]
+
 class SyncConfig(TypedDict):
     spotify: SpotifyConfig
-    sync_playlists: Optional[List[PlaylistConfig]]
-    excluded_playlists: Optional[List[str]]
+    sync_playlists: list[PlaylistConfig] | None
+    excluded_playlists: list[str] | None
+
+


### PR DESCRIPTION
Features
- Add ability to sync from tidal to spotify. This was implemented with backwards compatibility  and utilizing the existing cache
- Updated _some_ type hints to conform to 3.10

Need to add test code