### PR TITLE
Add another check to the spotify track sanity filter

### DIFF
--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -184,7 +184,11 @@ async def get_tracks_from_spotify_playlist(spotify_session: spotipy.Spotify, spo
     print(f"Loading tracks from Spotify playlist '{spotify_playlist['name']}'")
     items = await repeat_on_request_error( _fetch_all_from_spotify_in_chunks, lambda offset: _get_tracks_from_spotify_playlist(offset=offset, playlist_id=spotify_playlist["id"]))
     track_filter = lambda item: item.get('type', 'track') == 'track' # type may be 'episode' also
-    sanity_filter = lambda item: 'album' in item and 'name' in item['album'] and 'artists' in item['album'] and len(item['album']['artists']) > 0
+    sanity_filter = lambda item: ('album' in item
+                                  and 'name' in item['album']
+                                  and 'artists' in item['album']
+                                  and len(item['album']['artists']) > 0
+                                  and item['album']['artists'][0]['name'] is not None)
     return list(filter(sanity_filter, filter(track_filter, items)))
 
 def populate_track_match_cache(spotify_tracks_: Sequence[t_spotify.SpotifyTrack], tidal_tracks_: Sequence[tidalapi.Track]):


### PR DESCRIPTION
Discovered a crash when syncing a playlist with some random podcast episode. It crashed because both `['artists'][0]['name']` and `['album']['artists'][0]['name']` was None.

I thought the episode would be caught by the `track_filter`, but apparently having the 'type': 'episode' isn't reliable enough :/

Not sure if the check should be in the `sanity_filter` or any of the `_search_for...` methods in [tidal_search](https://github.com/spotify2tidal/spotify_to_tidal/blob/a438cda72b8aefcd8a7abd4e4e697a80c88db7b8/src/spotify_to_tidal/sync.py#L101) though.