### PR TITLE
using 127.0.0.1 as redirect uri instead of localhost works to meet th…

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -2,7 +2,7 @@ spotify:
   client_id: your_client_id
   client_secret: your_client_secret
   username: your_spotify_username
-  redirect_uri: http://localhost:8888/callback
+  redirect_uri: http://127.0.0.1:8888/callback
   open_browser: True # Set to False if using a headless server environment
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -23,7 +23,7 @@ def test_open_spotify_session(mocker):
         "username": "test_user",
         "client_id": "test_client_id",
         "client_secret": "test_client_secret",
-        "redirect_uri": "http://localhost/",
+        "redirect_uri": "http://127.0.0.1/",
         "open_browser": True,
     }
 
@@ -40,7 +40,7 @@ def test_open_spotify_session(mocker):
         scope=SPOTIFY_SCOPES,
         client_id="test_client_id",
         client_secret="test_client_secret",
-        redirect_uri="http://localhost/",
+        redirect_uri="http://127.0.0.1/",
         requests_timeout=2,
         open_browser=True,
     )
@@ -64,7 +64,7 @@ def test_open_spotify_session_oauth_error(mocker):
         "username": "test_user",
         "client_id": "test_client_id",
         "client_secret": "test_client_secret",
-        "redirect_uri": "http://localhost/",
+        "redirect_uri": "http://127.0.0.1/",
     }
 
     # Mock sys.exit to prevent the test from exiting


### PR DESCRIPTION
Due to new redirect URI restriction starting April 9th, localhost is no longer accepted. Using 127.0.0.1 instead does meet this. Changed all occurences of localhost to 127.0.0.1

https://developer.spotify.com/documentation/web-api/concepts/redirect_uri