### PR TITLE
Added preference for Atmos tracks

### DIFF
--- a/src/spotify_to_tidal/__main__.py
+++ b/src/spotify_to_tidal/__main__.py
@@ -10,6 +10,7 @@ def main():
     parser.add_argument('--config', default='config.yml', help='location of the config file')
     parser.add_argument('--uri', help='synchronize a specific URI instead of the one in the config')
     parser.add_argument('--sync-favorites', action=argparse.BooleanOptionalAction, help='synchronize the favorites')
+    parser.add_argument('--atmos', action='store_true', help='prefer Dolby Atmos tracks when available')
     args = parser.parse_args()
 
     with open(args.config, 'r') as f:
@@ -25,21 +26,21 @@ def main():
         spotify_playlist = spotify_session.playlist(args.uri)
         tidal_playlists = _sync.get_tidal_playlists_wrapper(tidal_session)
         tidal_playlist = _sync.pick_tidal_playlist_for_spotify_playlist(spotify_playlist, tidal_playlists)
-        _sync.sync_playlists_wrapper(spotify_session, tidal_session, [tidal_playlist], config)
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, [tidal_playlist], config, args.atmos)
         sync_favorites = args.sync_favorites # only sync favorites if command line argument explicitly passed
     elif args.sync_favorites:
         sync_favorites = True # sync only the favorites
     elif config.get('sync_playlists', None):
         # if the config contains a sync_playlists list of mappings then use that
-        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_playlists_from_config(spotify_session, tidal_session, config), config)
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_playlists_from_config(spotify_session, tidal_session, config), config, args.atmos)
         sync_favorites = args.sync_favorites is None and config.get('sync_favorites_default', True)
     else:
         # otherwise sync all the user playlists in the Spotify account and favorites unless explicitly disabled
-        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)
+        _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config, args.atmos)
         sync_favorites = args.sync_favorites is None and config.get('sync_favorites_default', True)
 
     if sync_favorites:
-        _sync.sync_favorites_wrapper(spotify_session, tidal_session, config)
+        _sync.sync_favorites_wrapper(spotify_session, tidal_session, config, args.atmos)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I used this app (thank you!) to sync my spotify tracks with Tidal so I could listen in my Lucid in Atmos.  This PR accepts an --atmos command line flag that tells the app to prefer atmos tracks.  This is done in two ways:
1. We search for track names with (Atmos) appended to the track name first.  This often requires removing other parentheses from the spotify track name, which required changing some matching logic, both in search matching and in sync (existing track) matching.
2. If an atmos track isn't found, we fallback to normal track searches, but iterate the results looking for a match that is Atmos.  

If neither of those are successful, we just add the normal track.