### PR TITLE
handle case where artist or artist name is empty

### DIFF
--- a/src/spotify_to_tidal/sync.py
+++ b/src/spotify_to_tidal/sync.py
@@ -55,16 +55,19 @@ def name_match(tidal_track, spotify_track) -> bool:
 
 def artist_match(tidal: tidalapi.Track | tidalapi.Album, spotify) -> bool:
     def split_artist_name(artist: str) -> Sequence[str]:
-       if '&' in artist:
-           return artist.split('&')
-       elif ',' in artist:
-           return artist.split(',')
-       else:
-           return [artist]
+        if not artist: return ['']
+        if '&' in artist:
+            return artist.split('&')
+        elif ',' in artist:
+            return artist.split(',')
+        else:
+            return [artist]
 
     def get_tidal_artists(tidal: tidalapi.Track | tidalapi.Album, do_normalize=False) -> Set[str]:
         result: list[str] = []
         for artist in tidal.artists:
+            if not artist.name:
+                continue
             if do_normalize:
                 artist_name = normalize(artist.name)
             else:
@@ -239,7 +242,7 @@ def get_tracks_for_new_tidal_playlist(spotify_tracks: Sequence[t_spotify.Spotify
             if tidal_id in seen_tracks:
                 track_name = spotify_track['name']
                 artist_names = ', '.join([artist['name'] for artist in spotify_track['artists']])
-                print(f'Duplicate found: Track "{track_name}" by {artist_names} will be ignored') 
+                print(f'Duplicate found: Track "{track_name}" by {artist_names} will be ignored')
             else:
                 output.append(tidal_id)
                 seen_tracks.add(tidal_id)
@@ -285,7 +288,7 @@ async def search_new_tracks_on_tidal(tidal_session: tidalapi.Session, spotify_tr
         for song in song404:
             file.write(f"{song}\n")
 
-            
+
 async def sync_playlist(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, spotify_playlist, tidal_playlist: tidalapi.Playlist | None, config: dict):
     """ sync given playlist to tidal """
     # Get the tracks from both Spotify and Tidal, creating a new Tidal playlist if necessary
@@ -319,7 +322,7 @@ async def sync_playlist(spotify_session: spotipy.Spotify, tidal_session: tidalap
 async def sync_favorites(spotify_session: spotipy.Spotify, tidal_session: tidalapi.Session, config: dict):
     """ sync user favorites to tidal """
     async def get_tracks_from_spotify_favorites() -> List[dict]:
-        _get_favorite_tracks = lambda offset: spotify_session.current_user_saved_tracks(offset=offset)    
+        _get_favorite_tracks = lambda offset: spotify_session.current_user_saved_tracks(offset=offset)
         tracks = await repeat_on_request_error( _fetch_all_from_spotify_in_chunks, _get_favorite_tracks)
         tracks.reverse()
         return tracks


### PR DESCRIPTION
I randomly came across this error while trying to move some playlists. I had to make these changes to finish the process, I hope it can be useful for other people too!

```
No playlist found on Tidal corresponding to Spotify playlist: 'Pumpkin soup', creating new playlist
Searching Tidal for 870/1178 tracks in Spotify playlist 'Pumpkin soup':  94%|█████████████████████████████████████▌  | 818/870 [01:17<00:04, 10.62it/s]
Traceback (most recent call last):
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/bin/spotify_to_tidal", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/__main__.py", line 38, in main
    _sync.sync_playlists_wrapper(spotify_session, tidal_session, _sync.get_user_playlist_mappings(spotify_session, tidal_session, config), config)
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 352, in sync_playlists_wrapper
    asyncio.run(sync_playlist(spotify_session, tidal_session, spotify_playlist, tidal_playlist, config) )
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 304, in sync_playlist
    await search_new_tracks_on_tidal(tidal_session, spotify_tracks, spotify_playlist['name'], config)
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 271, in search_new_tracks_on_tidal
    search_results = await atqdm.gather( *[ repeat_on_request_error(tidal_search, t, semaphore, tidal_session) for t in tracks_to_search ], desc=task_description )
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/site-packages/tqdm/asyncio.py", line 79, in gather
    res = [await f for f in cls.as_completed(ifs, loop=loop, timeout=timeout,
           ^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/asyncio/tasks.py", line 631, in _wait_for_one
    return f.result()  # May raise f.exception().
           ^^^^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/site-packages/tqdm/asyncio.py", line 76, in wrap_awaitable
    return i, await f
              ^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 140, in repeat_on_request_error
    return await function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 130, in tidal_search
    track_search = await asyncio.to_thread( _search_for_standalone_track )
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/.pyenv/versions/3.12.11/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 122, in _search_for_standalone_track
    if match(track, spotify_track):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 95, in match
    and artist_match(tidal_track, spotify_track)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 86, in artist_match
    if get_tidal_artists(tidal).intersection(get_spotify_artists(spotify)) != set():
       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 72, in get_tidal_artists
    result.extend(split_artist_name(artist_name))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/conorsheehan/Workspace/spotify_to_tidal/src/spotify_to_tidal/sync.py", line 58, in split_artist_name
    if '&' in artist:
       ^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```